### PR TITLE
Character Requirements and Min Length Customisation

### DIFF
--- a/src/PasswordChecker.php
+++ b/src/PasswordChecker.php
@@ -3,8 +3,7 @@ namespace FusionsPim\PhpPasswordChecker;
 
 class PasswordChecker
 {
-    private const MIN_LENGTH = 10; // Tied to the filtered password-blacklist.txt
-
+    private $minLength = 10; // Tied to the filtered password-blacklist.txt - unsure what this comment means?
     private $confirm;
     private $recentHashes;
     private $rejectAsTooObvious;
@@ -24,14 +23,19 @@ class PasswordChecker
         $this->recentHashes = $recentHashes;
     }
 
+    public function setMinLength(int $minLength): void
+    {
+        $this->minLength = $minLength;
+    }
+
     public function validate(string $password): bool
     {
         if (isset($this->confirm) && $this->confirm !== $password) {
             throw new PasswordException('New and confirmation passwords are different');
         }
 
-        if (mb_strlen($password) < static::MIN_LENGTH) {
-            throw new PasswordException(sprintf('New password must be at least %d characters long', static::MIN_LENGTH));
+        if (mb_strlen($password) < $this->minLength) {
+            throw new PasswordException(sprintf('New password must be at least %d characters long', $this->minLength));
         }
 
         if ($this->isPasswordBlacklisted($password)) {
@@ -44,6 +48,10 @@ class PasswordChecker
 
         if (isset($this->recentHashes) && $this->isRecentPassword($password)) {
             throw new PasswordException('New password has been used previously, choose another');
+        }
+
+        if (! empty($failedRequirements = $this->checkCharacterRequirements($password))) {
+            throw new PasswordException('New password should contain ' . $this->readableList($failedRequirements));
         }
 
         return true;
@@ -80,5 +88,34 @@ class PasswordChecker
         }
 
         return false;
+    }
+
+    public function checkCharacterRequirements(string $password): array
+    {
+        $requirements = [
+            ['/[a-z]/', '1 lower case letter'],
+            ['/[A-Z]/', '1 upper case letter'],
+            ['/[\d]/', '1 number'],
+            ['/[^a-zA-Z\d]/', '1 symbol'],
+        ];
+
+        $failures = [];
+
+        foreach ($requirements as [$regex, $description]) {
+            if (! preg_match($regex, $password)) {
+                $failures[] = $description;
+            }
+        }
+
+        return $failures;
+    }
+
+    private function readableList($items = [], $join = 'and'): string
+    {
+        if (count($items) > 1) {
+            return implode(', ', array_slice($items, 0, count($items) - 1)) . ' ' . $join . ' ' . $items[count($items) - 1];
+        }
+
+        return $items[0];
     }
 }

--- a/src/PasswordChecker.php
+++ b/src/PasswordChecker.php
@@ -3,7 +3,7 @@ namespace FusionsPim\PhpPasswordChecker;
 
 class PasswordChecker
 {
-    private $minLength = 10; // Tied to the filtered password-blacklist.txt - unsure what this comment means?
+    private $minLength = 10;
     private $confirm;
     private $recentHashes;
     private $rejectAsTooObvious;
@@ -25,7 +25,9 @@ class PasswordChecker
 
     public function setMinLength(int $minLength): void
     {
-        $this->minLength = $minLength;
+        if ($minLength > 10) {  // Tied to the filtered password-blacklist.txt
+            $this->minLength = $minLength;
+        }
     }
 
     public function validate(string $password): bool

--- a/src/PasswordChecker.php
+++ b/src/PasswordChecker.php
@@ -3,7 +3,9 @@ namespace FusionsPim\PhpPasswordChecker;
 
 class PasswordChecker
 {
-    private $minLength = 10;
+    public const MINIMUM_MIN_LENGTH = 10;  // Tied to the filtered password-blacklist.txt (no data for less than 10 characters)
+
+    private $minLength = self::MINIMUM_MIN_LENGTH;
     private $confirm;
     private $recentHashes;
     private $rejectAsTooObvious;
@@ -25,7 +27,7 @@ class PasswordChecker
 
     public function setMinLength(int $minLength): void
     {
-        if ($minLength > 10) {  // Tied to the filtered password-blacklist.txt
+        if ($minLength > self::MINIMUM_MIN_LENGTH) {
             $this->minLength = $minLength;
         }
     }

--- a/src/PasswordChecker.php
+++ b/src/PasswordChecker.php
@@ -114,7 +114,7 @@ class PasswordChecker
         return $failures;
     }
 
-    private function readableList($items = [], $join = 'and'): string
+    private function readableList(array $items = [], string $join = 'and'): string
     {
         if (count($items) > 1) {
             return implode(', ', array_slice($items, 0, count($items) - 1)) . ' ' . $join . ' ' . $items[count($items) - 1];

--- a/src/PasswordChecker.php
+++ b/src/PasswordChecker.php
@@ -27,7 +27,7 @@ class PasswordChecker
 
     public function setMinLength(int $minLength): void
     {
-        if ($minLength > self::MINIMUM_MIN_LENGTH) {
+        if ($minLength >= self::MINIMUM_MIN_LENGTH) {
             $this->minLength = $minLength;
         }
     }

--- a/tests/PasswordCheckerTest.php
+++ b/tests/PasswordCheckerTest.php
@@ -15,12 +15,12 @@ class PasswordCheckerTest extends TestCase
 
     public function test_valid_with_no_options(): void
     {
-        $this->assertTrue((new PasswordChecker)->validate('canyouhearme1'));
+        $this->assertTrue((new PasswordChecker)->validate('Canyouhearme1*'));
     }
 
     public function test_passes_due_to_new_password(): void
     {
-        $this->assertTrue($this->checker->validate('canyouhearme1'));
+        $this->assertTrue($this->checker->validate('Canyouhearme1*'));
     }
 
     public function test_fails_due_to_confirmation_mismatch(): void
@@ -38,6 +38,24 @@ class PasswordCheckerTest extends TestCase
         $this->expectExceptionMessage('New password must be at least 10 characters long');
 
         $this->checker->validate('abc');
+    }
+
+    public function test_fails_due_to_customized_length(): void
+    {
+        $this->checker->setMinLength(14);
+
+        $this->expectException(PasswordException::class);
+        $this->expectExceptionMessage('New password must be at least 14 characters long');
+
+        $this->checker->validate('canyouhearme1');
+    }
+
+    public function test_fails_due_to_character_requirements(): void
+    {
+        $this->expectException(PasswordException::class);
+        $this->expectExceptionMessage('New password should contain 1 upper case letter, 1 number and 1 symbol');
+
+        $this->checker->validate('canyouhearme');
     }
 
     public function test_fails_due_to_short_multibyte_password(): void

--- a/tests/PasswordCheckerTest.php
+++ b/tests/PasswordCheckerTest.php
@@ -50,12 +50,25 @@ class PasswordCheckerTest extends TestCase
         $this->checker->validate('canyouhearme1');
     }
 
+    /**
+     * @dataProvider fails_due_to_character_requirements_data_provider
+     */
     public function test_fails_due_to_character_requirements(): void
     {
         $this->expectException(PasswordException::class);
         $this->expectExceptionMessage('New password should contain 1 upper case letter, 1 number and 1 symbol');
 
         $this->checker->validate('canyouhearme');
+    }
+
+    public function fails_due_to_character_requirements_data_provider(): iterable
+    {
+        return [
+            ['canyouhearme', 'New password should contain 1 upper case letter, 1 number and 1 symbol'],
+            ['canyouhearme1', 'New password should contain 1 upper case letter and 1 symbol'],
+            ['canyouhearme1*', 'New password should contain 1 upper case letter'],
+            ['Canyouhearme1', 'New password should contain 1 symbol'],
+        ];
     }
 
     public function test_fails_due_to_short_multibyte_password(): void


### PR DESCRIPTION
With these changes the password checker will now force users to choose a password with:

- 1 upper case letter
- 1 lower case letter
- 1 number
- 1 symbol

I did experiment with making this feature user customisable but it added complexity and I'm not sure if we want to go that direction... other opinions welcome.

The minimum length can now also be increased via `$checker->setMinLength(14)`